### PR TITLE
Changed erroneous id to be _id to it doesn't populate the db like that

### DIFF
--- a/data/schedules/ozlan_bloodbowl_redux.py
+++ b/data/schedules/ozlan_bloodbowl_redux.py
@@ -125,7 +125,7 @@ schedule = [
         ]
     },
     {
-        "id": 6,
+        "_id": 6,
         "match": [
             {
                 "home": "Strong Independent Ladies",


### PR DESCRIPTION
The "id" field in object 6 was causing the db to give id as a populated field when in reality it was a mistake